### PR TITLE
Prioritize link uncharging

### DIFF
--- a/creep.behaviour.hauler.js
+++ b/creep.behaviour.hauler.js
@@ -20,8 +20,8 @@ module.exports = {
         let priority;
         if( _.sum(creep.carry) < creep.carryCapacity/2 ) { 
             priority = [
+                Creep.action.uncharging,
                 Creep.action.picking,
-                Creep.action.uncharging, 
                 Creep.action.withdrawing, 
                 Creep.action.idle];
         }

--- a/parameter.js
+++ b/parameter.js
@@ -36,6 +36,6 @@ var mod = {
     ROUTE_PRECALCULATION: false, 
     NOTIFICATE_INVADER: false, // Also log common 'Invader' hostiles
     COMBAT_CREEPS_RESPECT_RAMPARTS: false, // causes own creeps not to leave through ramparts
-    PLAYER_WHITELIST: ['cyberblast', 'Asku']
+    PLAYER_WHITELIST: ['cyberblast', 'Asku', 'SirLovi']
 }
 module.exports = mod;

--- a/room.js
+++ b/room.js
@@ -359,7 +359,7 @@ var mod = {
                     if (_.isUndefined(this._privateerMaxWeight) ) {
                         this._privateerMaxWeight = 0;
                         if ( !this.situation.invasion && !this.conserveForDefense ) {
-                            let base = 5000;
+                            let base = 6000;
                             let that = this;
                             let adjacent, ownNeighbor, room, mult;
 


### PR DESCRIPTION
Haulers get confused when central and mining link are full, trying to pick up dropped energy instead of uncharging the central link to solve the jam.
And small changes.