### PR TITLE
Dont allow worker/privateer upgrading with storage

### DIFF
--- a/creep.action.upgrading.js
+++ b/creep.action.upgrading.js
@@ -2,9 +2,6 @@ var action = new Creep.Action('upgrading');
 action.targetRange = 3;
 action.isAddableAction = function(creep){ 
     return !creep.room.storage;
-    if( creep.room.storage ) 
-        return creep.room.storage.store.energy > MAX_STORAGE_ENERGY;
-    return true; 
 };
 action.isAddableTarget = function(target){ return true; }; 
 action.isValidAction = function(creep){

--- a/creep.action.upgrading.js
+++ b/creep.action.upgrading.js
@@ -1,6 +1,7 @@
 var action = new Creep.Action('upgrading');
 action.targetRange = 3;
 action.isAddableAction = function(creep){ 
+    return !creep.room.storage;
     if( creep.room.storage ) 
         return creep.room.storage.store.energy > MAX_STORAGE_ENERGY;
     return true; 

--- a/creep.setup.hauler.js
+++ b/creep.setup.hauler.js
@@ -8,14 +8,16 @@ setup.maxMulti = function(room) {
         max += 2; 
     let contSum = _.sum(room.containerIn.map(e => _.sum(e.store)));
     max += Math.floor(contSum / 1000);
+    max += Creep.setup.upgrader.maxMulti(room);
     return max;
 };
 setup.maxCount = function(room){
+    let count = 0;
     if(room.population && room.population.typeCount['miner'] > 0) {
-        if( room.links.length > 2) return 1;
-        else return 2;
+        count += Creep.setup.upgrader.maxCount(room);
+        if( room.links.length < 3) count++;
     }
-    return 0; 
+    return count; 
 };
 setup.default = {
     fixedBody: [], 


### PR DESCRIPTION
For quite a while, worker weren't allowed to upgrade the controller as soon as there is a storage (due to a bug). 
In the meanwhile the upgrader is much more variable in its size, and I like that. 
Now (as the bug is fixed) workers (and privateers!) will support with upgrading (as soon as the storage level reaches MAX_STORAGE_ENERGY). That will block them to do other jobs. 
I believe the upgrader is able to manage the energy level of the storage on its own (will become larger/smaller), and should do it alone. 

What do you think?